### PR TITLE
Update README.md - added ./ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Clone the repository and install the package with apt.
 
 ```commandline
 make package
-apt install apt-server_1.0.0_all.deb
+apt install ./apt-server_1.0.0_all.deb
 ```
 
 ### From GitHub release
@@ -47,7 +47,7 @@ apt install apt-server_1.0.0_all.deb
 Download the latest release from the GitHub repository and install the package with apt.
 
 ```commandline
-apt install apt-server_1.0.0_all.deb
+apt install ./apt-server_1.0.0_all.deb
 ``` 
 
 ## Usage


### PR DESCRIPTION
without prefix the apt will not use local package file and give error

`E: Unable to locate package apt-server_1.1.5_all.deb`